### PR TITLE
Allow Symfony3

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,7 +7,7 @@
         <service id="gfreeau_get_jwt.security.authentication.listener"
                  class="Gfreeau\Bundle\GetJWTBundle\Security\Firewall\GetJWTListener" public="false" abstract="true">
             <tag name="monolog.logger" channel="security" />
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authentication.manager" />
             <argument /> <!-- Provider-shared Key -->
             <argument type="service" id="lexik_jwt_authentication.handler.authentication_success" />

--- a/Security/Firewall/GetJWTListener.php
+++ b/Security/Firewall/GetJWTListener.php
@@ -2,8 +2,8 @@
 
 namespace Gfreeau\Bundle\GetJWTBundle\Security\Firewall;
 
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
@@ -30,7 +30,7 @@ class GetJWTListener implements ListenerInterface
     private $failureHandler;
 
     /**
-     * @param SecurityContextInterface $securityContext
+     * @param TokenStorageInterface $securityContext
      * @param AuthenticationManagerInterface $authenticationManager
      * @param $providerKey
      * @param AuthenticationSuccessHandlerInterface $successHandler
@@ -39,7 +39,7 @@ class GetJWTListener implements ListenerInterface
      * @param LoggerInterface $logger
      * @throws InvalidArgumentException
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler = null, array $options = array(), LoggerInterface $logger = null)
+    public function __construct(TokenStorageInterface $securityContext, AuthenticationManagerInterface $authenticationManager, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler = null, array $options = array(), LoggerInterface $logger = null)
     {
         if (empty($providerKey)) {
             throw new InvalidArgumentException('$providerKey must not be empty.');

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "~2.3",
-        "symfony/framework-bundle": "~2.3",
-        "lexik/jwt-authentication-bundle": "~1.2"
+        "symfony/symfony": "~2.6|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "lexik/jwt-authentication-bundle": "^2.0.x-dev"
     },
     "autoload": {
         "psr-0": { "Gfreeau\\Bundle\\GetJWTBundle": "" }


### PR DESCRIPTION
raised Symfony minimum to 2.6 to be able to use the `TokenStorageInterface` (switched to `2.0-dev` for the JWT Bundle which also enables Symfony 3.0)
